### PR TITLE
Pass more details into logger for error

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -426,7 +426,7 @@ class AudiConnectVehicle:
         err = message + ": " + str(exception).rstrip("\n")
         if not err in self._logged_errors:
             self._logged_errors.add(err)
-            _LOGGER.error(err)
+            _LOGGER.error(err, exception)
 
     async def update_vehicle_statusreport(self):
         if not self.support_status_report:

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -426,7 +426,7 @@ class AudiConnectVehicle:
         err = message + ": " + str(exception).rstrip("\n")
         if not err in self._logged_errors:
             self._logged_errors.add(err)
-            _LOGGER.error(err, exception)
+            _LOGGER.error(err, exc_info=True)
 
     async def update_vehicle_statusreport(self):
         if not self.support_status_report:


### PR DESCRIPTION
This PR should optimize error output, not very important for the end user but it doesn't harm in future to have the callstack in the logger as well.

This extends for example errors like this where it is not clear where the error is coming from:
`2023-12-22 14:06:12.582 ERROR (MainThread) [custom_components.audiconnect.audi_connect_account] Unable to obtain the vehicle status report of WAUZZZFZ9NP015583: 'charging'
`